### PR TITLE
✨ Feat: 장소선택필터 리셋기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/app/travel-info/page.tsx
+++ b/src/app/travel-info/page.tsx
@@ -40,8 +40,8 @@ export default function TravelInfo() {
       ? `&sigunguCode=${selectedSigunguCode}`
       : '';
     const url = keywordParam.length
-      ? `http://apis.data.go.kr/B551011/KorService1/searchKeyword1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}${keywordParam}`
-      : `http://apis.data.go.kr/B551011/KorService1/areaBasedList1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}`;
+      ? `https://apis.data.go.kr/B551011/KorService1/searchKeyword1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}${keywordParam}`
+      : `https://apis.data.go.kr/B551011/KorService1/areaBasedList1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}`;
     try {
       const response = await fetch(url);
       if (!response.ok) {
@@ -99,7 +99,7 @@ export default function TravelInfo() {
   };
 
   useEffect(() => {
-    fetchData(1, true); // 초기화면
+    fetchData(1, true); // 컴포넌트가 마운트될 때 초기 데이터 가져오기
   }, []);
 
   return (

--- a/src/app/travel-info/page.tsx
+++ b/src/app/travel-info/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   SearchKeyword,
   PlacesList,
@@ -8,42 +8,25 @@ import {
   CategoryFilter,
 } from '@/widgets';
 import { PlaceT } from '@/widgets/travel-info/types/Place';
+import { AiOutlineReload } from 'react-icons/ai';
+import useInfiniteScroll from '@/widgets/travel-info/hooks/useInfiniteScroll';
 
 export default function TravelInfo() {
-  const [keyword, setKeyword] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
-    null
-  );
-  const [selectedCategoryName, setSelectedCategoryName] = useState('');
+  const [keyword, setKeyword] = useState<string>('');
   const [selectedAreaCode, setSelectedAreaCode] = useState<number | null>(null);
+  const [selectedAreaName, setSelectedAreaName] = useState<string>('');
   const [selectedSigunguCode, setSelectedSigunguCode] = useState<number | null>(
     null
   );
+  const [selectedSigunguName, setSelectedSigunguName] = useState<string>('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    null
+  );
+  const [selectedCategoryName, setSelectedCategoryName] = useState<string>('');
 
   const [apiData, setApiData] = useState<PlaceT[] | null>(null);
-  const [page, setPage] = useState(0);
+  const [page, setPage] = useState<number>(0);
   const [hasMore, setHasMore] = useState(false);
-  const loader = useRef<HTMLDivElement | null>(null);
-
-  const handleCategorySelect = (contentTypeId: number | null) => {
-    setSelectedCategoryId(contentTypeId);
-  };
-  const handleAreaSelect = (areaCode: number | null) => {
-    setSelectedAreaCode(areaCode);
-  };
-  const handleSigunguSelect = (sigunguCode: number | null) => {
-    setSelectedSigunguCode(sigunguCode);
-  };
-
-  const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
-
-  const handleSearch = async (searchKeyword: string) => {
-    setKeyword(searchKeyword);
-    setPage(0);
-    setHasMore(true);
-    scrollToTop();
-    await fetchData(1, true);
-  };
 
   const fetchData = async (pageNo: number, isNewSearch = false) => {
     const contentTypeIdParam = selectedCategoryId
@@ -57,8 +40,8 @@ export default function TravelInfo() {
       ? `&sigunguCode=${selectedSigunguCode}`
       : '';
     const url = keywordParam.length
-      ? `https://apis.data.go.kr/B551011/KorService1/searchKeyword1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}${keywordParam}`
-      : `https://apis.data.go.kr/B551011/KorService1/areaBasedList1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}`;
+      ? `http://apis.data.go.kr/B551011/KorService1/searchKeyword1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}${keywordParam}`
+      : `http://apis.data.go.kr/B551011/KorService1/areaBasedList1?numOfRows=10&pageNo=${pageNo}&MobileOS=ETC&MobileApp=APPTest&serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&_type=json&listYN=Y&arrange=O${contentTypeIdParam}${areaCodeParam}${sigunguCodeParam}`;
     try {
       const response = await fetch(url);
       if (!response.ok) {
@@ -84,38 +67,40 @@ export default function TravelInfo() {
     }
   };
 
-  const observer = useRef<IntersectionObserver | null>(null);
+  const loader = useInfiniteScroll(hasMore, () =>
+    setPage((prevPage) => prevPage + 1)
+  );
 
   useEffect(() => {
-    if (observer.current) observer.current.disconnect();
-
-    observer.current = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && hasMore) {
-        setPage((prevPage) => prevPage + 1);
-      }
-    });
-
-    if (loader.current) observer.current.observe(loader.current);
-
-    return () => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, [hasMore]);
-
-  useEffect(() => {
-    if (page > 1) {
+    if (page >= 1) {
       fetchData(page);
     }
   }, [page]);
 
+  const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
+
+  const handleSearch = async () => {
+    setPage(0);
+    setHasMore(true);
+    scrollToTop();
+    await fetchData(1, true);
+  };
+
   const handleReset = () => {
     setKeyword('');
-    setApiData(null);
-    setPage(0);
-    setHasMore(false);
+    setSelectedAreaCode(null);
+    setSelectedAreaName('');
+    setSelectedSigunguCode(null);
+    setSelectedSigunguName('');
     setSelectedCategoryId(null);
     setSelectedCategoryName('');
+    setPage(0);
+    setHasMore(false);
   };
+
+  useEffect(() => {
+    fetchData(1, true); // 초기화면
+  }, []);
 
   return (
     <div className="relative h-full w-full">
@@ -123,31 +108,37 @@ export default function TravelInfo() {
         <button
           type="button"
           onClick={handleReset}
-          disabled={!apiData || apiData.length === 0}
-          className={`bg-transparent px-4 py-2 ${!apiData || apiData.length === 0 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:font-bold hover:text-[--brand-color]'}`}
+          disabled={!apiData}
+          className={`flex flex-col items-center justify-center bg-transparent px-4 py-2 text-xs ${!apiData ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:font-bold hover:text-[--brand-color]'}`}
         >
+          <AiOutlineReload className="mr-2" size={20} />
           선택초기화
         </button>
         <div className="flex-1 space-y-4 py-4">
           <AreaFilter
-            onAreaSelect={handleAreaSelect}
-            onSigunguSelect={handleSigunguSelect}
+            selectedAreaCode={selectedAreaCode}
+            setSelectedAreaCode={setSelectedAreaCode}
+            selectedSigunguCode={selectedSigunguCode}
+            setSelectedSigunguCode={setSelectedSigunguCode}
+            selectedAreaName={selectedAreaName}
+            setSelectedAreaName={setSelectedAreaName}
+            selectedSigunguName={selectedSigunguName}
+            setSelectedSigunguName={setSelectedSigunguName}
           />
           <CategoryFilter
-            onCategorySelect={handleCategorySelect}
+            selectedCategoryId={selectedCategoryId}
+            setSelectedCategoryId={setSelectedCategoryId}
             selectedCategoryName={selectedCategoryName}
             setSelectedCategoryName={setSelectedCategoryName}
           />
         </div>
-        <SearchKeyword
-          keyword={keyword}
-          setKeyword={setKeyword}
-          onSearch={handleSearch}
-        />
+        <div className="flex items-center">
+          <SearchKeyword setKeyword={setKeyword} onSearch={handleSearch} />
+        </div>
       </div>
       <div className="h-full w-full">
         {apiData && apiData.length ? (
-          <div className="w-1/2 overflow-y-auto">
+          <div className="w-full overflow-y-auto">
             <PlacesList apiData={apiData} />
           </div>
         ) : (

--- a/src/widgets/travel-info/components/AreaFilter.tsx
+++ b/src/widgets/travel-info/components/AreaFilter.tsx
@@ -3,27 +3,34 @@
 import { useState } from 'react';
 import AreaCode from './AreaCode';
 
+interface AreaFilterProps {
+  selectedAreaCode: number | null;
+  setSelectedAreaCode: (code: number | null) => void;
+  selectedSigunguCode: number | null;
+  setSelectedSigunguCode: (code: number | null) => void;
+  selectedAreaName: string;
+  setSelectedAreaName: (name: string) => void;
+  selectedSigunguName: string;
+  setSelectedSigunguName: (name: string) => void;
+}
+
 export default function AreaFilter({
-  onAreaSelect,
-  onSigunguSelect,
-}: {
-  onAreaSelect: (areaCode: number | null) => void;
-  onSigunguSelect: (sigunguCode: number | null) => void;
-}) {
+  selectedAreaCode,
+  setSelectedAreaCode,
+  selectedSigunguCode,
+  setSelectedSigunguCode,
+  selectedAreaName,
+  setSelectedAreaName,
+  selectedSigunguName,
+  setSelectedSigunguName,
+}: AreaFilterProps) {
   const [data, setData] = useState<any[] | null>(null);
   const [select, setSelect] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedAreaCode, setSelectedAreaCode] = useState<number | null>(null);
-  const [selectedSigunguCode, setSelectedSigunguCode] = useState<number | null>(
-    null
-  );
-  const [selectedAreaName, setSelectedAreaName] = useState<string | null>(null);
-  const [selectedSigunguName, setSelectedSigunguName] = useState<string | null>(
-    null
-  );
 
   const url = `https://apis.data.go.kr/B551011/KorService1/areaCode1?serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&numOfRows=100&MobileOS=ETC&MobileApp=APPTest&_type=json`;
 
+  // 지역 목록 불러오기
   const fetchData = async () => {
     setError(null);
     try {
@@ -42,37 +49,32 @@ export default function AreaFilter({
     }
   };
 
+  // 지역선택 클릭
   const handleClick = () => {
-    if (!select && !data) fetchData();
-    setSelect((prev) => !prev);
+    if (!data) fetchData(); // 최초 클릭 시 지역목록 불러오기
+    setSelect((prev) => !prev); // true면 드롭박스 나타남
   };
 
+  // 드롭박스에서 지역 선택
   const handleAreaClick = (areaCode: number, areaName: string) => {
-    setSelectedAreaCode((prevCode) =>
-      prevCode === areaCode ? null : areaCode
-    );
-    setSelectedAreaName((prevName) =>
-      prevName === areaName ? null : areaName
-    );
+    // 두번 선택하면 선택해제
+    setSelectedAreaCode(selectedAreaCode === areaCode ? null : areaCode);
+    setSelectedAreaName(selectedAreaName === areaName ? '' : areaName);
+
+    // 시군구 선택은 초기화
     setSelectedSigunguCode(null);
-    setSelectedSigunguName(null);
-    onSigunguSelect(null);
-    if (selectedAreaCode === areaCode) {
-      onAreaSelect(null);
-    } else {
-      onAreaSelect(areaCode);
-    }
+    setSelectedSigunguName('');
   };
 
+  // 시군구 선택
   const handleSigunguClick = (sigunguCode: number, sigunguName: string) => {
-    setSelectedSigunguCode((prevCode) =>
-      prevCode === sigunguCode ? null : sigunguCode
+    setSelectedSigunguCode(
+      selectedSigunguCode === sigunguCode ? null : sigunguCode
     );
-    setSelectedSigunguName((prevName) =>
-      prevName === sigunguName ? null : sigunguName
+    setSelectedSigunguName(
+      selectedSigunguName === sigunguName ? '' : sigunguName
     );
-    onSigunguSelect(selectedSigunguCode);
-    setSelect(false);
+    setSelect(false); // 시군구까지 선택하면 드롭박스 닫힘
   };
 
   return (
@@ -92,7 +94,7 @@ export default function AreaFilter({
       )}
       {error && <p>오류: {error}</p>}
       <section
-        className={`absolute left-0 top-12 z-10 w-32 bg-gray-100 py-[4px] text-sm transition-all duration-500 ease-in-out ${select ? 'h-[416px] opacity-100' : 'h-0 opacity-0'}`}
+        className={`absolute left-0 top-7 z-10 w-32 bg-gray-100 py-[4px] text-sm transition-all duration-500 ease-in-out ${select ? 'h-[416px] opacity-100' : 'h-0 opacity-0'}`}
       >
         {select &&
           data &&

--- a/src/widgets/travel-info/components/CategoryFilter.tsx
+++ b/src/widgets/travel-info/components/CategoryFilter.tsx
@@ -2,17 +2,20 @@
 
 import { useState } from 'react';
 
-export default function CategoryFilter({
-  onCategorySelect,
-  selectedCategoryName,
-  setSelectedCategoryName,
-}: {
-  onCategorySelect: (contentTypeId: number | null) => void;
+interface CategoryFilterProps {
   selectedCategoryName: string;
   setSelectedCategoryName: (name: string) => void;
-}) {
+  selectedCategoryId: number | null;
+  setSelectedCategoryId: (name: number | null) => void;
+}
+
+export default function CategoryFilter({
+  selectedCategoryName,
+  setSelectedCategoryName,
+  selectedCategoryId,
+  setSelectedCategoryId,
+}: CategoryFilterProps) {
   const [select, setSelect] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
 
   const categories = [
     { name: '관광지', contentTypeId: 12 },
@@ -24,21 +27,21 @@ export default function CategoryFilter({
     { name: '음식', contentTypeId: 39 },
   ];
 
+  // select=true면 카테고리 목록 드롭박스 나타남
   const handleClick = () => {
     setSelect((prev) => !prev);
   };
 
   const handleCategoryClick = (name: string, contentTypeId: number) => {
-    if (selectedCategory === contentTypeId) {
-      setSelectedCategory(null);
-      onCategorySelect(null);
+    // 동일 카테고리 두번 클릭 시 선택 초기화
+    if (selectedCategoryId === contentTypeId) {
+      setSelectedCategoryId(null);
       setSelectedCategoryName('');
     } else {
-      setSelectedCategory(contentTypeId);
-      onCategorySelect(contentTypeId);
+      setSelectedCategoryId(contentTypeId);
       setSelectedCategoryName(name);
     }
-    setSelect(false);
+    setSelect(false); // 카테고리 선택 시 드롭박스 닫힘
   };
 
   return (
@@ -54,7 +57,7 @@ export default function CategoryFilter({
         <span className="font-bold text-[--brand-color]">{` > ${selectedCategoryName}`}</span>
       )}
       <section
-        className={`absolute left-0 top-12 w-32 bg-gray-100 py-[4px] text-sm transition-all duration-500 ease-in-out ${select ? 'h-[176px] opacity-100' : 'h-0 opacity-0'}`}
+        className={`absolute left-0 top-7 w-32 bg-gray-100 py-[4px] text-sm transition-all duration-500 ease-in-out ${select ? 'h-[176px] opacity-100' : 'h-0 opacity-0'}`}
       >
         {select &&
           categories.map((type) => (
@@ -65,7 +68,7 @@ export default function CategoryFilter({
                   handleCategoryClick(type.name, type.contentTypeId)
                 }
                 className={`w-full text-center hover:font-bold hover:text-[--brand-color] ${
-                  selectedCategory === type.contentTypeId
+                  selectedCategoryId === type.contentTypeId
                     ? 'font-bold text-[--brand-color]'
                     : ''
                 }`}

--- a/src/widgets/travel-info/components/PlacesList.tsx
+++ b/src/widgets/travel-info/components/PlacesList.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { PlaceT, PlaceDetailT } from '@/widgets/travel-info/types/Place';
 import { KakaoMap } from '@/shared';
+import Link from 'next/link';
+import { AiOutlineHome } from 'react-icons/ai';
 
 interface PlacesListProps {
   apiData: PlaceT[] | null;
@@ -22,7 +24,7 @@ export default function PlacesList({ apiData }: PlacesListProps) {
       setExpandedId(contentId);
       if (!detailedData[contentId]) {
         try {
-          const url = `https://apis.data.go.kr/B551011/KorService1/detailCommon1?serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&contentId=${contentId}&MobileOS=ETC&MobileApp=APPTest&_type=json&defaultYN=Y&firstImageYN=Y&addrinfoYN=Y&mapinfoYN=Y&overviewYN=Y`;
+          const url = `http://apis.data.go.kr/B551011/KorService1/detailCommon1?serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&contentId=${contentId}&MobileOS=ETC&MobileApp=APPTest&_type=json&defaultYN=Y&firstImageYN=Y&addrinfoYN=Y&mapinfoYN=Y&overviewYN=Y`;
           const response = await fetch(url);
           if (!response.ok) {
             throw new Error('Network response was not ok.');
@@ -49,7 +51,7 @@ export default function PlacesList({ apiData }: PlacesListProps) {
           >
             <button
               type="button"
-              className="flex w-full text-left"
+              className="flex w-1/2 text-left"
               onClick={() => handleToggle(place.contentid)}
             >
               <figure className="relative m-4 flex h-44 w-44 items-center justify-center">
@@ -89,7 +91,7 @@ export default function PlacesList({ apiData }: PlacesListProps) {
               </article>
             </button>
             <div
-              className={`overflow-hidden transition-all duration-500 ease-in-out ${
+              className={`w-1/2 overflow-hidden transition-all duration-500 ease-in-out ${
                 expandedId === place.contentid
                   ? 'max-h-screen opacity-100'
                   : 'max-h-0 opacity-0'
@@ -101,17 +103,19 @@ export default function PlacesList({ apiData }: PlacesListProps) {
                     {detailedData[place.contentid]?.homepage && (
                       <article>
                         <h3 className="text-base font-bold hover:text-[#3666FF]">
-                          <a
+                          <Link
                             href={
                               detailedData[place.contentid]?.homepage.split(
                                 '"'
-                              )[1]
+                              )[1] || '#'
                             }
                             target="_blank"
                             rel="noopener noreferrer"
+                            className="flex"
                           >
                             홈페이지
-                          </a>
+                            <AiOutlineHome className="ml-2" size={24} />
+                          </Link>
                         </h3>
                       </article>
                     )}
@@ -130,7 +134,7 @@ export default function PlacesList({ apiData }: PlacesListProps) {
                       </article>
                     )}
                     {detailedData[place.contentid]?.mapx && (
-                      <article className="fixed left-[50%] top-20 h-full w-1/2 max-w-[512px] pr-8">
+                      <article className="fixed left-[50%] top-20 h-full w-1/2 max-w-[512px] pl-2 pr-8">
                         <KakaoMap
                           mapx={detailedData[place.contentid]?.mapx}
                           mapy={detailedData[place.contentid]?.mapy}

--- a/src/widgets/travel-info/components/PlacesList.tsx
+++ b/src/widgets/travel-info/components/PlacesList.tsx
@@ -24,7 +24,7 @@ export default function PlacesList({ apiData }: PlacesListProps) {
       setExpandedId(contentId);
       if (!detailedData[contentId]) {
         try {
-          const url = `http://apis.data.go.kr/B551011/KorService1/detailCommon1?serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&contentId=${contentId}&MobileOS=ETC&MobileApp=APPTest&_type=json&defaultYN=Y&firstImageYN=Y&addrinfoYN=Y&mapinfoYN=Y&overviewYN=Y`;
+          const url = `https://apis.data.go.kr/B551011/KorService1/detailCommon1?serviceKey=${process.env.NEXT_PUBLIC_TOUR_API_KEY}&contentId=${contentId}&MobileOS=ETC&MobileApp=APPTest&_type=json&defaultYN=Y&firstImageYN=Y&addrinfoYN=Y&mapinfoYN=Y&overviewYN=Y`;
           const response = await fetch(url);
           if (!response.ok) {
             throw new Error('Network response was not ok.');

--- a/src/widgets/travel-info/components/SearchKeyword.tsx
+++ b/src/widgets/travel-info/components/SearchKeyword.tsx
@@ -4,13 +4,11 @@ import { ChangeEvent } from 'react';
 import { SearchBar } from '@/shared';
 
 interface FilterAreaProps {
-  keyword: string;
   setKeyword: (keyword: string) => void;
-  onSearch: (keyword: string) => void;
+  onSearch: () => void;
 }
 
 export default function SearchKeyword({
-  keyword,
   setKeyword,
   onSearch,
 }: FilterAreaProps) {
@@ -20,12 +18,8 @@ export default function SearchKeyword({
 
   const handleInputKeyPress = (event: KeyboardEvent) => {
     if (event.key === 'Enter') {
-      handleSearch();
+      onSearch();
     }
-  };
-
-  const handleSearch = () => {
-    onSearch(keyword);
   };
 
   return (
@@ -33,15 +27,14 @@ export default function SearchKeyword({
       <div className="relative">
         <button
           type="button"
-          onClick={handleSearch}
+          onClick={onSearch}
           className="absolute left-[5px] top-[5px] h-[30px] w-[30px] bg-white px-4 py-2 text-[0px] opacity-0 hover:opacity-50"
           aria-label="검색버튼"
         />
         <SearchBar
-          value={keyword}
           onChange={handleInputChange}
-          placeholder="장소를 검색하세요"
           onKeyPress={handleInputKeyPress}
+          placeholder="장소를 검색하세요"
         />
       </div>
     </div>

--- a/src/widgets/travel-info/hooks/useInfiniteScroll.ts
+++ b/src/widgets/travel-info/hooks/useInfiniteScroll.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+function useInfiniteScroll(hasMore: boolean, loadMore: () => void) {
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (observerRef.current) observerRef.current.disconnect();
+
+    observerRef.current = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        loadMore();
+      }
+    });
+
+    if (loaderRef.current) observerRef.current.observe(loaderRef.current);
+
+    return () => {
+      if (observerRef.current) observerRef.current.disconnect();
+    };
+  }, [hasMore]);
+
+  return loaderRef;
+}
+
+export default useInfiniteScroll;


### PR DESCRIPTION
1. 필터 초기화 기능 추가 (지역, 카테고리 선택)
- 상태변수들 상위 컴포넌트로 올리고 일부 중복 변수들 정리했습니다

2. 초기화면 구현

3. 무한스크롤 로직 훅으로 분리

4. 레이아웃 수정
- 초기 목록의 너비 100% -> 상세정보 표출될 때 절반으로
- 지도와 상세정보 사이 공백추가
- 필터 선택시 드롭박스의 top margin 조정