### PR TITLE
[✨ Feat] 회원가입, 로그인, 로그아웃 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11523,9 +11523,9 @@
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -12860,9 +12860,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -15284,9 +15284,9 @@
       "peer": true
     },
     "node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
       "peer": true,
       "dependencies": {
         "async-limiter": "~1.0.0"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Header } from '@/widgets';
 import { Metadata } from 'next';
 import { Toaster } from '@/components/ui/toaster';
+import { AuthProvider } from '@/shared';
 import ReactQueryProvider from './ReactQueryProvider';
 
 const notoSansKR = Noto_Sans_KR({
@@ -25,11 +26,13 @@ export default function RootLayout({
     <html lang="ko" className="min-h-svh">
       <body className={`${notoSansKR.className} min-h-svh`}>
         <ReactQueryProvider>
-          <div className="relative mx-auto min-h-svh min-w-[360px] max-w-[1024px] px-8 text-[--text-default-color] disabled:!bg-[--deactivated-color] disabled:!text-[--deactivated-text-color]">
-            <Header />
-            <main>{children}</main>
-            <Toaster />
-          </div>
+          <AuthProvider>
+            <div className="relative mx-auto min-h-svh min-w-[360px] max-w-[1024px] px-8 text-[--text-default-color] disabled:!bg-[--deactivated-color] disabled:!text-[--deactivated-text-color]">
+              <Header />
+              <main>{children}</main>
+              <Toaster />
+            </div>
+          </AuthProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/src/shared/api/AuthContext.tsx
+++ b/src/shared/api/AuthContext.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import {
+  createContext,
+  useState,
+  useContext,
+  ReactNode,
+  useEffect,
+} from 'react';
+
+interface AuthContextProps {
+  jwt: string | null;
+  setJwt: (jwt: string | null) => void;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [jwt, setJwt] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('jwt');
+    setJwt(token);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ jwt, setJwt }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/shared/index.tsx
+++ b/src/shared/index.tsx
@@ -22,3 +22,4 @@ export { default as EditScheduleButton } from './ui/EditScheduleButton';
 export { default as KakaoMap } from './ui/KakaoMap';
 export { THEMES } from './constants/themes';
 export { WIDTH } from './constants/style';
+export { AuthProvider, useAuth } from './api/AuthContext';

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -5,6 +5,7 @@
 import { GiHamburgerMenu } from 'react-icons/gi';
 import { useRef } from 'react';
 import { IoMdClose } from 'react-icons/io';
+import { useAuth } from '@/shared';
 import GNB from './GNB';
 import JoinLink from './JoinLink';
 import LoginLink from './LoginLink';
@@ -21,6 +22,7 @@ export default function Header() {
     navDivRef.current?.classList.remove('right-0');
     navDivRef.current?.classList.add('-right-full');
   };
+  const { jwt } = useAuth();
 
   return (
     <header className=" flex items-center justify-between py-6 ">
@@ -41,14 +43,17 @@ export default function Header() {
         </div>
       </div>
       <div className="absolute right-[74px] text-sm md:static">
-        <div className="space-x-4">
-          <LoginLink />
-          <JoinLink />
-        </div>
-        <div className="hidden space-x-4">
-          <MyPageLink />
-          <LogoutButton />
-        </div>
+        {jwt ? (
+          <div className="space-x-4">
+            <MyPageLink />
+            <LogoutButton />
+          </div>
+        ) : (
+          <div className="space-x-4">
+            <LoginLink />
+            <JoinLink />
+          </div>
+        )}
       </div>
       <button
         className="absolute right-[36px] top-[31px]  md:hidden"

--- a/src/widgets/header/ui/LogoutButton.tsx
+++ b/src/widgets/header/ui/LogoutButton.tsx
@@ -1,3 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/shared';
+
 export default function LogoutButton() {
-  return <button type="button">로그아웃</button>;
+  const router = useRouter();
+  const { setJwt } = useAuth();
+
+  const handleLogout = () => {
+    localStorage.removeItem('jwt');
+    setJwt(null);
+    alert('로그아웃 되었습니다.');
+    router.push('/');
+  };
+
+  return (
+    <button type="button" onClick={handleLogout}>
+      로그아웃
+    </button>
+  );
 }

--- a/src/widgets/header/ui/MyPageLink.tsx
+++ b/src/widgets/header/ui/MyPageLink.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
 
 export default function MyPageLink() {
-  return <Link href="/mypage">마이페이지</Link>;
+  return <Link href="/my-page">마이페이지</Link>;
 }

--- a/src/widgets/join/ui/JoinForm.tsx
+++ b/src/widgets/join/ui/JoinForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
+import fetcher from '@/shared/utils/fetcher';
 
 const formSchema = z
   .object({
@@ -61,11 +62,31 @@ export default function JoinForm() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  const BASE_URL = 'http://lyckabc.synology.me:20280';
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
     const { confirmPassword, ...userInfo } = values;
-    console.log(userInfo);
-    alert('회원가입에 성공했습니다');
-    router.push('/login');
+    try {
+      const response = await fetcher(
+        BASE_URL,
+        '/auth/join',
+        'post',
+        {
+          'Content-Type': 'application/json',
+        },
+        undefined,
+        userInfo
+      );
+
+      console.log(response);
+      if (response && response.data.success) {
+        alert('회원가입에 성공했습니다');
+        router.push('/login');
+      }
+    } catch (error: any) {
+      console.error('에러:', error);
+      if (error.response.data.message) alert(error.response.data.message);
+    }
   }
 
   const [showPassword, setShowPassword] = useState(false);

--- a/src/widgets/join/ui/JoinForm.tsx
+++ b/src/widgets/join/ui/JoinForm.tsx
@@ -47,6 +47,8 @@ const formSchema = z
     path: ['confirmPassword'],
   });
 
+const BASE_URL = 'http://lyckabc.synology.me:20280';
+
 export default function JoinForm() {
   const router = useRouter();
 


### PR DESCRIPTION
회원가입
- 회원정보 POST요청
- 기존 회원정보와 일치하는 경우 없으면 "회원가입 완료" 알림창 보여주고 로그인페이지로 이동

로그인
- 아이디, 비밀번호 POST 요청
- 일치하는 회원정보 있으면 서버 응답 header에서 jwt 발급받음
- localstrorage에 jwt 저장 후 메인페이지로 이동
- 웹페이지 헤더의 로그인, 회원가입 버튼은 로그아웃, 마이페이지 버튼으로 변경

로그아웃
- 로그아웃버튼 누르면 localstorage에서 jwt 삭제

카카오로그인은 별개로 추가예정입니다.