### PR TITLE
[✨ Feat] 카카오로그인 구현

### DIFF
--- a/src/app/kakao-redirect/page.tsx
+++ b/src/app/kakao-redirect/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { fetcher, TRAVEL_URL, useAuth } from '@/shared';
+
+export default function KakaoRedirect() {
+  const { setJwt } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetcher(
+          TRAVEL_URL,
+          '/auth/jwt',
+          'get',
+          undefined,
+          undefined,
+          undefined,
+          true
+        );
+        const jwt = response && response.headers.authorization;
+        if (jwt) {
+          localStorage.setItem('jwt', jwt);
+          setJwt(jwt);
+          alert('로그인 되었습니다.');
+          router.push('/');
+        } else {
+          console.error('JWT 토큰이 없습니다.');
+        }
+      } catch (error: any) {
+        console.error('에러:', error);
+        alert(error.message);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <h1 className="text-xl font-bold">로그인 처리 중...</h1>
+    </div>
+  );
+}

--- a/src/shared/utils/fetcher.ts
+++ b/src/shared/utils/fetcher.ts
@@ -11,7 +11,9 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (axios.isAxiosError(error)) {
-      return Promise.reject(new Error(error.message));
+      return Promise.reject(
+        new Error(error.response?.data?.message || error.message)
+      );
     }
     return Promise.reject(new Error('An unknown error occurred'));
   }
@@ -23,7 +25,8 @@ const fetcher = async (
   method: 'get' | 'post' | 'put' | 'delete',
   headers?: Record<string, string>,
   params?: Record<string, any>,
-  data?: any
+  data?: any,
+  withCredentials?: boolean
 ): Promise<any> => {
   try {
     const fullUrl = `${baseurl}${url}`;
@@ -32,6 +35,7 @@ const fetcher = async (
       url: fullUrl,
       headers,
       params,
+      withCredentials,
       ...(method !== 'get' && data && { data }),
     };
 
@@ -44,7 +48,7 @@ const fetcher = async (
       return error;
     }
     console.error('Unexpected error:', error);
-    throw new Error('Unexpected error occurred');
+    throw error;
   }
 };
 

--- a/src/widgets/login/ui/LogInForm.tsx
+++ b/src/widgets/login/ui/LogInForm.tsx
@@ -60,11 +60,14 @@ export default function LogInForm() {
         console.error('JWT not found in the response headers');
       }
     } catch (error: any) {
-      // 네트워크 오류 또는 기타 예외 처리
-      console.error('에러', error);
+      alert(error.message);
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleKakaoLogin = () => {
+    router.push(`${TRAVEL_URL}/oauth2/authorization/kakao`);
   };
 
   return (
@@ -131,6 +134,7 @@ export default function LogInForm() {
             backgroundSize: 'cover',
             backgroundPosition: 'center',
           }}
+          onClick={handleKakaoLogin}
         />
         <div className="flex justify-between text-sm">
           <Link href="/find-username" className="hover:text-[#3666FF]">


### PR DESCRIPTION
카카오로그인 구현 건입니다.

**변경사항**
1. LoginForm.tsx
- 카카오로그인 버튼 클릭 시 지정된 경로로 이동
- 이동한 주소에서 카카오로그인, 회원정보 제공 동의 진행
- 서버에서 카카오서버와 사용자 인증 진행 및 쿠키에 jwt 발급 후 "/kakao-redirect"로 리다이렉트

2. KakaoRedirect.tsx
- 쿠키에 있는 jwt를 서버에 전송 후 header로 발급받아 localStorage에 저장, 로그인처리 후 메인페이지("/")로 이동

3. fetcher.ts
- 쿠키를 서버에 전송하기 위해 withCredentials 속성 추가
- 서버에서 설정한 에러메시지를 활용하기 위해 인터셉터 수정

