### PR TITLE
[🐛 fix] 일정 삭제, 수정, 생성 등 Mutate 이후 Stale 데이터 표시 문제 해결

### DIFF
--- a/src/widgets/my-plan-list/ui/MyPlans.tsx
+++ b/src/widgets/my-plan-list/ui/MyPlans.tsx
@@ -59,7 +59,7 @@ export default function MyPlans() {
               <PiSpinnerGapLight className="h-[32px] w-[32px]" />
             </div>
           )}
-          {isFetching && <div ref={observerRef} />}
+          {!isFetching && <div ref={observerRef} />}
         </div>
       )}
     </div>

--- a/src/widgets/plan-detail/model/usePlan.ts
+++ b/src/widgets/plan-detail/model/usePlan.ts
@@ -20,6 +20,7 @@ export const usePlan = (plan_id: number) => {
     mutationFn: (plan_id: number) => deletePlan(plan_id, jwt as string),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['plans'] });
+      await queryClient.refetchQueries({ queryKey: ['plans'] });
       router.replace('/my-travels');
       await queryClient.invalidateQueries({ queryKey: ['plan', plan_id] });
     },

--- a/src/widgets/plan-editor/model/useForm.ts
+++ b/src/widgets/plan-editor/model/useForm.ts
@@ -86,21 +86,43 @@ export const useForm = (
 
   const { mutate: mutateCreatePlan } = useMutation({
     mutationFn: (data: PostNewPlanT) => postNewPlan(data, jwt as string),
-    onSuccess: (data) => {
-      queryClient
-        .invalidateQueries({ queryKey: ['plan', plan?.plan_id] })
-        .then(() => {
-          router.push(`/my-travels/plan/${data.plan_id}`);
-        });
+    onSuccess: async (data) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['plans'] }),
+        queryClient.invalidateQueries({ queryKey: ['upcomingPlans'] }),
+      ]);
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: ['plans'] }),
+        queryClient.refetchQueries({ queryKey: ['upcomingPlans'] }),
+      ]);
+
+      router.push(`/my-travels/plan/${data.plan_id}`);
     },
   });
 
   const { mutate: mutateUpdatePlan } = useMutation({
     mutationFn: (data: PostNewPlanT) =>
       putPlan(data, plan?.plan_id as number, jwt as string),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['plan', plan?.plan_id.toString()],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['plans'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['upcomingPlans'],
+        }),
+      ]);
+      await Promise.all([
+        queryClient.refetchQueries({
+          queryKey: ['plan', plan?.plan_id.toString()],
+        }),
+        queryClient.refetchQueries({ queryKey: ['plans'] }),
+        queryClient.refetchQueries({ queryKey: ['upcomingPlans'] }),
+      ]);
+
+      router.push(`/my-travels/plan/${plan?.plan_id}`);
       if (setIsEditMode) setIsEditMode(false);
-      queryClient.invalidateQueries({ queryKey: ['plan'] });
     },
   });
 


### PR DESCRIPTION
### 작업 내용
- Mutate 이후 invalidateQueries 실행했음에도 뒤로가기 또는 같은 url 에서 UI만 변경되는 경우 stale한 데이터 표시되는 문제 해결
- invalidateQueries 이후 refetchQueries를 실행하여 뒤로가기 시 새로운 데이터 가져오게 함
- 동일한 url의 경우 useRouter.push()를 사용해 새로운 데이터를 가져오게 함