### PR TITLE
[🐛 fix] '스크랩 많은 순' 정렬 시  데이터 패칭 오류 해결

### DIFF
--- a/src/widgets/user-travel-list/types/user-travel-type.ts
+++ b/src/widgets/user-travel-list/types/user-travel-type.ts
@@ -30,4 +30,4 @@ export type GetUserTravelPlanSuccessT = {
   nextCursor?: number;
 };
 
-export type SortType = 'newest' | 'scrap';
+export type SortType = 'newest' | 'scraps';

--- a/src/widgets/user-travel-list/ui/filter-and-sort/TravelSort.tsx
+++ b/src/widgets/user-travel-list/ui/filter-and-sort/TravelSort.tsx
@@ -21,7 +21,7 @@ export default function TravelSort() {
 
       <SelectContent>
         <SelectItem value="newest">최신순</SelectItem>
-        <SelectItem value="scrap">스크랩 많은 순</SelectItem>
+        <SelectItem value="scraps">스크랩 많은 순</SelectItem>
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
### 스크린샷
![image](https://github.com/team-MiniJin/FE/assets/58039782/e701bcbf-d2a1-4a1d-946d-61c85ab049a9)

### 작업 내용
- url에 포함된 'scrap'을 'scraps'로 수정